### PR TITLE
Fixed BT2WE conversion issue with sound variables

### DIFF
--- a/BetterTriggers/BT2WE.cs
+++ b/BetterTriggers/BT2WE.cs
@@ -440,7 +440,10 @@ namespace BetterTriggers
                         }
                         else if (returnType == "sound")
                         {
-                            prefix = "gg_snd_";
+                            if (!paramValue.Contains("gg_snd_"))
+                            {
+                                prefix = "gg_snd_";
+                            }
                             isVariable = true;
                         }
                         else if (returnType == "StringExt")


### PR DESCRIPTION
Fixed BT2WE conversion issue where sound variables already had a "gg_snd_ " prefix, causing compile errors in the World Editor.

From issue: https://github.com/TheLazzoro/BetterTriggers/issues/16